### PR TITLE
Refactor globals to context

### DIFF
--- a/packages/babel-plugin/src/builders.js
+++ b/packages/babel-plugin/src/builders.js
@@ -1,4 +1,7 @@
-import { types as t } from '@babel/core'
+import { types as t, traverse } from '@babel/core'
+
+import { SCALES_MAP, SYSTEM_ALIASES, INTERNAL_PROP_ID } from './constants'
+import { createMediaQuery, castArray, shouldSkipProp } from './utils'
 
 /**
  * Builds a babel AST like the following: `value !== undefined ? value : fallbackValue`.
@@ -7,12 +10,13 @@ import { types as t } from '@babel/core'
  * @param {Object} fallbackValue - babel AST to falsily use.
  * @returns The conditional fallback babel AST.
  */
-export const buildUndefinedConditionalFallback = (value, fallbackValue) =>
-  t.conditionalExpression(
+export const buildUndefinedConditionalFallback = (value, fallbackValue) => {
+  return t.conditionalExpression(
     t.binaryExpression('!==', value, t.identifier('undefined')),
     value,
     fallbackValue,
   )
+}
 
 /**
  * Builds a babel AST for a variable declaration e.g. `const var = true`.
@@ -22,15 +26,358 @@ export const buildUndefinedConditionalFallback = (value, fallbackValue) =>
  * @param {Object} right - babel AST for the right hand side of the declaration.
  * @returns The variable declaration AST.
  */
-export const buildVariableDeclaration = (type, left, right) =>
-  t.variableDeclaration(type, [
+export const buildVariableDeclaration = (type, left, right) => {
+  return t.variableDeclaration(type, [
     t.variableDeclarator(t.assignmentPattern(left, right)),
   ])
+}
 
 /**
- * Builds a babel AST for a spread operator. e.g. `...arr`.
+ * Processes an attribute node and returns the value, stripping any
+ * negatives if necessary.
  *
- * @param {Object} expression - Babel expression to spread.
- * @returns The spread operator AST.
+ * @param {Object} attrValue - babel ast node to strip.
+ * @returns A tuple containing the base value and a boolean
+ * indicating if the value was negative.
  */
-export const buildSpreadElement = expression => t.spreadElement(expression)
+export const buildBaseValueAttr = attrValue => {
+  const isNegative =
+    (t.isUnaryExpression(attrValue) && attrValue.operator === '-') ||
+    (t.isStringLiteral(attrValue) && attrValue.value[0] === '-')
+
+  let baseAttrValue = attrValue
+
+  if (isNegative && t.isUnaryExpression(attrValue))
+    baseAttrValue = attrValue.argument
+  if (isNegative && t.isStringLiteral(attrValue))
+    baseAttrValue = t.stringLiteral(attrValue.value.substring(1))
+
+  return [baseAttrValue, isNegative]
+}
+
+/**
+ * Given a css prop name and node, returns the equivalent theme aware
+ * accessor expression.
+ *
+ * @param {string} propName - Name of the prop being converted.
+ * @param {Object} attrValue - Babel AST to convert.
+ * @param {Object} options - Optional options for this utility.
+ * @returns The equivalent theme appropriate AST.
+ */
+export const buildThemeAwareExpression = (
+  context,
+  propName,
+  attrValue,
+  {
+    withUndefinedFallback = true,
+    withNegativeTransform = true,
+    mediaIndex = 0,
+  } = {},
+) => {
+  const { variants, stylingLibrary, propsToPass, themeIdentifierPath } = context
+
+  const scaleName = SCALES_MAP[propName] || variants[propName]
+  if (!scaleName) return attrValue
+
+  const [attrBaseValue, isNegative] = buildBaseValueAttr(attrValue)
+  let stylingLibraryAttrValue = attrBaseValue // emotion
+
+  if (stylingLibrary === 'styled-components' && propsToPass[propName])
+    stylingLibraryAttrValue = t.memberExpression(
+      t.memberExpression(
+        t.memberExpression(t.identifier('p'), t.identifier(INTERNAL_PROP_ID)),
+        t.identifier(propName),
+      ),
+      t.numericLiteral(mediaIndex),
+      true,
+    )
+
+  let themeExpression = t.memberExpression(
+    t.memberExpression(
+      t.identifier(themeIdentifierPath),
+      t.stringLiteral(scaleName),
+      true,
+    ),
+    stylingLibraryAttrValue,
+    true,
+  )
+
+  if (withUndefinedFallback)
+    themeExpression = buildUndefinedConditionalFallback(
+      themeExpression,
+      stylingLibraryAttrValue,
+    )
+
+  if (withNegativeTransform && isNegative)
+    themeExpression = t.binaryExpression(
+      '+',
+      t.stringLiteral('-'),
+      t.parenthesizedExpression(themeExpression),
+    )
+
+  return themeExpression
+}
+
+/**
+ * Given a prop name and babel node, returns an object property containing
+ * the prop name as the key and the appropriate theme-aware accessor as it's
+ * value.
+ *
+ * @param {string} propName - Prop name to build
+ * @param {Object} attrValue - Babel node to build into theme-aware accessor.
+ * @param {Object} param2 - Optional options. Used for specifying the current media
+ * breakpoint.
+ */
+export const buildCssObjectProp = (
+  context,
+  propName,
+  attrValue,
+  { mediaIndex = 0 } = {},
+) => {
+  return t.objectProperty(
+    t.identifier(propName),
+    buildThemeAwareExpression(context, propName, attrValue, { mediaIndex }),
+  )
+}
+
+/**
+ * Function to perform any related side-effects for a system prop,
+ * e.g. adding it to our private-prop accumulator for `styled-components`.
+ * @private
+ *
+ * @param {string} propName - The name of the system prop to process.
+ * @param {Object} attrValue - The Babel node to process.
+ */
+const _preprocessProp = (context, propName, attrValue) => {
+  const { propsToPass } = context
+
+  const [attrBaseValue, isNegative] = buildBaseValueAttr(attrValue)
+
+  propsToPass[propName] = propsToPass[propName] || []
+
+  if (isNegative) propsToPass[propName].push(attrBaseValue)
+  else propsToPass[propName].push(attrValue)
+}
+
+/**
+ * Builds an array of theme-aware babel Object Properties for the `css`
+ * prop from a list of system-prop-JSX attribute nodes.
+ *
+ * @param {Array} attrNodes - Array of JSX attributes.
+ * @param {Array} breakpoints - Media query breakpoints.
+ * @returns An array with the theme aware object properties.
+ */
+export const buildCssObjectProperties = (context, attrNodes, breakpoints) => {
+  const { variants } = context
+  const baseResult = []
+  const responsiveResults = []
+
+  attrNodes.forEach(attrNode => {
+    const attrName = attrNode.name.name
+    const attrValue = attrNode.value
+    const cssPropertyNames = castArray(SYSTEM_ALIASES[attrName] || attrName)
+
+    if (t.isJSXExpressionContainer(attrValue)) {
+      // e.g prop={}
+      const expression = attrValue.expression
+
+      if (t.isArrayExpression(expression)) {
+        // e.g. prop={['test', null, 'test2']}
+        expression.elements.forEach((element, i) => {
+          responsiveResults[i] = responsiveResults[i] || []
+
+          const resultArr = i === 0 ? baseResult : responsiveResults[i - 1]
+
+          cssPropertyNames.forEach(cssPropertyName => {
+            _preprocessProp(context, cssPropertyName, element)
+            if (shouldSkipProp(element)) return
+
+            resultArr.push(
+              buildCssObjectProp(context, cssPropertyName, element, {
+                mediaIndex: i,
+              }),
+            )
+          })
+        })
+      } else {
+        // e.g. prop={bool ? 'foo' : "test"}, prop={'test'}, prop={text}
+        cssPropertyNames.forEach(cssPropertyName => {
+          _preprocessProp(context, cssPropertyName, expression)
+          if (shouldSkipProp(expression)) return
+
+          baseResult.push(
+            buildCssObjectProp(context, cssPropertyName, expression),
+          )
+        })
+      }
+    } else {
+      // e.g. prop="test"
+      const isVariant = Boolean(variants[attrNode.name.name])
+
+      cssPropertyNames.forEach(cssPropertyName => {
+        _preprocessProp(context, cssPropertyName, attrValue)
+        if (shouldSkipProp(attrValue)) return
+
+        if (isVariant)
+          baseResult.push(
+            t.spreadElement(
+              buildThemeAwareExpression(context, cssPropertyName, attrValue, {
+                withUndefinedFallback: false,
+                withNegativeTransform: false,
+              }),
+            ),
+          )
+        else
+          baseResult.push(
+            buildCssObjectProp(context, cssPropertyName, attrValue),
+          )
+      })
+    }
+  })
+
+  const keyedResponsiveResults = responsiveResults
+    .map((objectPropertiesForBreakpoint, i) => {
+      const mediaQuery = createMediaQuery(breakpoints[i])
+
+      return t.objectProperty(
+        t.stringLiteral(mediaQuery),
+        t.objectExpression(objectPropertiesForBreakpoint),
+      )
+    })
+    .filter(results => results.value.properties.length)
+
+  return [...baseResult, ...keyedResponsiveResults]
+}
+
+/**
+ * Builds the JSX AST for the `css` prop given a list of
+ * object property ASTs.
+ *
+ * @param {Array} objectProperties - List of object properties.
+ * @returns A JSX attribute AST for the `css` prop.
+ */
+export const buildCssAttr = (context, objectProperties) => {
+  const { themeIdentifier } = context
+
+  return t.jsxAttribute(
+    t.jSXIdentifier('css'),
+    t.jSXExpressionContainer(
+      t.arrowFunctionExpression(
+        [t.identifier(themeIdentifier)],
+        t.objectExpression(objectProperties),
+      ),
+    ),
+  )
+}
+
+/**
+ * Given a function expression from a `css` prop, returns a tuple
+ * containining an array of the body statements from the expression,
+ * and the return statement of the expression.
+ *
+ * Also handles renaming any existing identifiers from the
+ * function expression's parameters or destructured parameters that are used
+ * in the function expression body or return statement.
+ *
+ * @param {Object} expression - Babel function/arrow function expression node.
+ * @returns The tuple of body statements and return statement.
+ */
+const _extractAndCleanFunctionParts = (context, expression) => {
+  const { themeIdentifier } = context
+
+  const functionBody = expression.body
+  const functionParam = expression.params[0]
+  let bodyStatements = []
+
+  if (t.isIdentifier(functionParam)) {
+    // e.g. css={theme => }
+    traverse(
+      functionBody,
+      {
+        Identifier(path, exisitingParamName) {
+          if (path.node.name === exisitingParamName) {
+            path.node.name = themeIdentifier
+          }
+        },
+      },
+      expression,
+      functionParam.name,
+    )
+  } else if (t.isObjectPattern(functionParam)) {
+    // e.g. css={({ colors, theme }) => }
+    bodyStatements = [
+      buildVariableDeclaration(
+        'const',
+        functionParam,
+        t.identifier(themeIdentifier),
+      ),
+    ]
+  }
+
+  if (t.isObjectExpression(functionBody)) {
+    // e.g. css={theme => ({ ... })}
+    return [bodyStatements, functionBody.properties]
+  } else if (t.isBlockStatement(functionBody)) {
+    // e.g. css={theme => { return { ... } }}
+    const exisitingBodyStatements = functionBody.body.filter(
+      node => !t.isReturnStatement(node),
+    )
+    const returnStatement = functionBody.body.find(node =>
+      t.isReturnStatement(node),
+    )
+
+    bodyStatements = [...bodyStatements, ...exisitingBodyStatements]
+
+    // TODO: throw error if returnStatement.argument is not an object.
+    return [bodyStatements, returnStatement.argument.properties]
+  }
+}
+
+/**
+ * Builds a merged `css` prop given a list of theme aware object properties and
+ * the existing CSS prop Babel node.
+ *
+ * @param {Array} objectProperties - Theme aware object properties.
+ * @param {Object} existingCssAttr - The Babel node of an existing `css` prop.
+ * @returns The merged `css` prop node.
+ */
+export const buildMergedCssAttr = (
+  context,
+  objectProperties,
+  existingCssAttr,
+) => {
+  const { themeIdentifier } = context
+
+  const existingExpression = existingCssAttr.value.expression
+  let mergedProperties = []
+  let bodyStatements = []
+
+  if (t.isObjectExpression(existingExpression))
+    mergedProperties = [...objectProperties, ...existingExpression.properties]
+  else if (t.isFunction(existingExpression)) {
+    const [
+      extractedBodyStatements,
+      returnObjectProperties,
+    ] = _extractAndCleanFunctionParts(context, existingExpression)
+
+    bodyStatements = extractedBodyStatements
+    mergedProperties = [...objectProperties, ...returnObjectProperties]
+  }
+
+  const hasBodyStatements = bodyStatements.length
+
+  return t.jsxAttribute(
+    t.jSXIdentifier('css'),
+    t.jSXExpressionContainer(
+      t.arrowFunctionExpression(
+        [t.identifier(themeIdentifier)],
+        hasBodyStatements
+          ? t.blockStatement([
+              ...bodyStatements,
+              t.returnStatement(t.objectExpression(mergedProperties)),
+            ])
+          : t.objectExpression(mergedProperties),
+      ),
+    ),
+  )
+}

--- a/packages/babel-plugin/src/constants.js
+++ b/packages/babel-plugin/src/constants.js
@@ -2,6 +2,8 @@ import camelCase from 'lodash.camelcase'
 import cssProps from 'known-css-properties'
 import isPropValid from '@emotion/is-prop-valid'
 
+export const INTERNAL_PROP_ID = '__styleProps__'
+
 export const STYLING_LIBRARIES = {
   styledComponents: {
     identifier: 'p',

--- a/packages/babel-plugin/src/index.js
+++ b/packages/babel-plugin/src/index.js
@@ -1,375 +1,16 @@
-import svgTags from 'svg-tags'
-import { types as t, traverse } from '@babel/core'
+import { types as t } from '@babel/core'
 
 import {
-  SYSTEM_ALIASES,
   DEFAULT_OPTIONS,
-  SCALES_MAP,
   STYLING_LIBRARIES,
+  INTERNAL_PROP_ID,
 } from './constants'
+import { onlySystemProps, notSystemProps } from './utils'
 import {
-  castArray,
-  createMediaQuery,
-  onlySystemProps,
-  notSystemProps,
-} from './utils'
-import {
-  buildUndefinedConditionalFallback,
-  buildVariableDeclaration,
-  buildSpreadElement,
+  buildCssObjectProperties,
+  buildCssAttr,
+  buildMergedCssAttr,
 } from './builders'
-
-/**
- * Strips and returns the base value of a negative babel AST.
- *
- * @param {Object} attrValue - babel ast node to strip.
- * @returns A tuple containing the base value and a boolean
- * indicating if the value was negative.
- */
-const stripNegativeFromAttrValue = attrValue => {
-  const isNegative =
-    (t.isUnaryExpression(attrValue) && attrValue.operator === '-') ||
-    (t.isStringLiteral(attrValue) && attrValue.value[0] === '-')
-
-  let baseAttrValue = attrValue
-
-  if (isNegative && t.isUnaryExpression(attrValue))
-    baseAttrValue = attrValue.argument
-  if (isNegative && t.isStringLiteral(attrValue))
-    baseAttrValue = t.stringLiteral(attrValue.value.substring(1))
-
-  return [baseAttrValue, isNegative]
-}
-
-/**
- * Given a css prop name and node, returns the equivalent theme aware
- * accessor expression.
- *
- * @param {string} propName - Name of the prop being converted.
- * @param {Object} attrValue - Babel AST to convert.
- * @param {Object} options - Optional options for this utility.
- * @returns The equivalent theme appropriate AST.
- */
-const attrToThemeExpression = (
-  context,
-  propName,
-  attrValue,
-  {
-    withUndefinedFallback = true,
-    withNegativeTransform = true,
-    mediaIndex = 0,
-  } = {},
-) => {
-  const { variants, stylingLibrary, propsToPass, themeIdentifierPath } = context
-
-  const scaleName = SCALES_MAP[propName] || variants[propName]
-  if (!scaleName) return attrValue
-
-  const [attrBaseValue, isNegative] = stripNegativeFromAttrValue(attrValue)
-  let stylingLibraryAttrValue = attrBaseValue // emotion
-
-  if (stylingLibrary === 'styled-components' && propsToPass[propName])
-    stylingLibraryAttrValue = t.memberExpression(
-      t.memberExpression(
-        t.memberExpression(t.identifier('p'), t.identifier('__styleProps')),
-        t.identifier(propName),
-      ),
-      t.numericLiteral(mediaIndex),
-      true,
-    )
-
-  let themeExpression = t.memberExpression(
-    t.memberExpression(
-      t.identifier(themeIdentifierPath),
-      t.stringLiteral(scaleName),
-      true,
-    ),
-    stylingLibraryAttrValue,
-    true,
-  )
-
-  if (withUndefinedFallback)
-    themeExpression = buildUndefinedConditionalFallback(
-      themeExpression,
-      stylingLibraryAttrValue,
-    )
-
-  if (withNegativeTransform && isNegative)
-    themeExpression = t.binaryExpression(
-      '+',
-      t.stringLiteral('-'),
-      t.parenthesizedExpression(themeExpression),
-    )
-
-  return themeExpression
-}
-
-/**
- * Checks if the provided Babel node is skippable by checking
- * if it is `null`.
- *
- * @param {Object} attrValue - Babel node to check.
- * @returns `true` if it is skippable, `false` otherwise.
- */
-const shouldSkipProp = attrValue => t.isNullLiteral(attrValue)
-
-/**
- * Function to perform any related side-effects for a system prop,
- * e.g. adding it to our private-prop accumulator for `styled-components`.
- *
- * @param {string} propName - The name of the system prop to process.
- * @param {Object} attrValue - The Babel node to process.
- */
-const preprocessProp = (context, propName, attrValue) => {
-  const { propsToPass } = context
-
-  const [attrBaseValue, isNegative] = stripNegativeFromAttrValue(attrValue)
-
-  propsToPass[propName] = propsToPass[propName] || []
-
-  if (isNegative) propsToPass[propName].push(attrBaseValue)
-  else propsToPass[propName].push(attrValue)
-}
-
-/**
- * Given a prop name and babel node, returns an object property containing
- * the prop name as the key and the appropriate theme-aware accessor as it's
- * value.
- *
- * @param {string} propName - Prop name to build
- * @param {Object} attrValue - Babel node to build into theme-aware accessor.
- * @param {Object} param2 - Optional options. Used for specifying the current media
- * breakpoint.
- */
-const buildCssObjectProp = (
-  context,
-  propName,
-  attrValue,
-  { mediaIndex = 0 } = {},
-) =>
-  t.objectProperty(
-    t.identifier(propName),
-    attrToThemeExpression(context, propName, attrValue, { mediaIndex }),
-  )
-
-/**
- * Builds an array of theme-aware babel Object Properties for the `css`
- * prop from a list of system-prop-JSX attribute nodes.
- *
- * @param {Array} attrNodes - Array of JSX attributes.
- * @param {Array} breakpoints - Media query breakpoints.
- * @returns An array with the theme aware object properties.
- */
-const buildCssObjectProperties = (context, attrNodes, breakpoints) => {
-  const { variants } = context
-  const baseResult = []
-  const responsiveResults = []
-
-  attrNodes.forEach(attrNode => {
-    const attrName = attrNode.name.name
-    const attrValue = attrNode.value
-    const cssPropertyNames = castArray(SYSTEM_ALIASES[attrName] || attrName)
-
-    if (t.isJSXExpressionContainer(attrValue)) {
-      // e.g prop={}
-      const expression = attrValue.expression
-
-      if (t.isArrayExpression(expression)) {
-        // e.g. prop={['test', null, 'test2']}
-        expression.elements.forEach((element, i) => {
-          responsiveResults[i] = responsiveResults[i] || []
-
-          const resultArr = i === 0 ? baseResult : responsiveResults[i - 1]
-
-          cssPropertyNames.forEach(cssPropertyName => {
-            preprocessProp(context, cssPropertyName, element)
-            if (shouldSkipProp(element)) return
-
-            resultArr.push(
-              buildCssObjectProp(context, cssPropertyName, element, {
-                mediaIndex: i,
-              }),
-            )
-          })
-        })
-      } else {
-        // e.g. prop={bool ? 'foo' : "test"}, prop={'test'}, prop={text}
-        cssPropertyNames.forEach(cssPropertyName => {
-          preprocessProp(context, cssPropertyName, expression)
-          if (shouldSkipProp(expression)) return
-
-          baseResult.push(
-            buildCssObjectProp(context, cssPropertyName, expression),
-          )
-        })
-      }
-    } else {
-      // e.g. prop="test"
-      const isVariant = Boolean(variants[attrNode.name.name])
-
-      cssPropertyNames.forEach(cssPropertyName => {
-        preprocessProp(context, cssPropertyName, attrValue)
-        if (shouldSkipProp(attrValue)) return
-
-        if (isVariant)
-          baseResult.push(
-            buildSpreadElement(
-              attrToThemeExpression(context, cssPropertyName, attrValue, {
-                withUndefinedFallback: false,
-                withNegativeTransform: false,
-              }),
-            ),
-          )
-        else
-          baseResult.push(
-            buildCssObjectProp(context, cssPropertyName, attrValue),
-          )
-      })
-    }
-  })
-
-  const keyedResponsiveResults = responsiveResults
-    .map((objectPropertiesForBreakpoint, i) => {
-      const mediaQuery = createMediaQuery(breakpoints[i])
-
-      return t.objectProperty(
-        t.stringLiteral(mediaQuery),
-        t.objectExpression(objectPropertiesForBreakpoint),
-      )
-    })
-    .filter(results => results.value.properties.length)
-
-  return [...baseResult, ...keyedResponsiveResults]
-}
-
-/**
- * Builds the JSX AST for the `css` prop given a list of
- * object property ASTs.
- *
- * @param {Array} objectProperties - List of object properties.
- * @returns A JSX attribute AST for the `css` prop.
- */
-const buildCssAttr = (context, objectProperties) => {
-  const { themeIdentifier } = context
-
-  return t.jsxAttribute(
-    t.jSXIdentifier('css'),
-    t.jSXExpressionContainer(
-      t.arrowFunctionExpression(
-        [t.identifier(themeIdentifier)],
-        t.objectExpression(objectProperties),
-      ),
-    ),
-  )
-}
-
-/**
- * Given a function expression from a `css` prop, returns a tuple
- * containining an array of the body statements from the expression,
- * and the return statement of the expression.
- *
- * Also handles renaming any existing identifiers from the
- * function expression's parameters or destructured parameters that are used
- * in the function expression body or return statement.
- *
- * @param {Object} expression - Babel function/arrow function expression node.
- * @returns The tuple of body statements and return statement.
- */
-const extractAndCleanFunctionParts = (context, expression) => {
-  const { themeIdentifier } = context
-
-  const functionBody = expression.body
-  const functionParam = expression.params[0]
-  let bodyStatements = []
-
-  if (t.isIdentifier(functionParam)) {
-    // e.g. css={theme => }
-    traverse(
-      functionBody,
-      {
-        Identifier(path, exisitingParamName) {
-          if (path.node.name === exisitingParamName) {
-            path.node.name = themeIdentifier
-          }
-        },
-      },
-      expression,
-      functionParam.name,
-    )
-  } else if (t.isObjectPattern(functionParam)) {
-    // e.g. css={({ colors, theme }) => }
-    bodyStatements = [
-      buildVariableDeclaration(
-        'const',
-        functionParam,
-        t.identifier(themeIdentifier),
-      ),
-    ]
-  }
-
-  if (t.isObjectExpression(functionBody)) {
-    // e.g. css={theme => ({ ... })}
-    return [bodyStatements, functionBody.properties]
-  } else if (t.isBlockStatement(functionBody)) {
-    // e.g. css={theme => { return { ... } }}
-    const exisitingBodyStatements = functionBody.body.filter(
-      node => !t.isReturnStatement(node),
-    )
-    const returnStatement = functionBody.body.find(node =>
-      t.isReturnStatement(node),
-    )
-
-    bodyStatements = [...bodyStatements, ...exisitingBodyStatements]
-
-    // TODO: throw error if returnStatement.argument is not an object.
-    return [bodyStatements, returnStatement.argument.properties]
-  }
-}
-
-/**
- * Builds a merged `css` prop given a list of theme aware object properties and
- * the existing CSS prop Babel node.
- *
- * @param {Array} objectProperties - Theme aware object properties.
- * @param {Object} existingCssAttr - The Babel node of an existing `css` prop.
- * @returns The merged `css` prop node.
- */
-const buildMergedCssAttr = (context, objectProperties, existingCssAttr) => {
-  const { themeIdentifier } = context
-
-  const existingExpression = existingCssAttr.value.expression
-  let mergedProperties = []
-  let bodyStatements = []
-
-  if (t.isObjectExpression(existingExpression))
-    mergedProperties = [...objectProperties, ...existingExpression.properties]
-  else if (t.isFunction(existingExpression)) {
-    const [
-      extractedBodyStatements,
-      returnObjectProperties,
-    ] = extractAndCleanFunctionParts(context, existingExpression)
-
-    bodyStatements = extractedBodyStatements
-    mergedProperties = [...objectProperties, ...returnObjectProperties]
-  }
-
-  const hasBodyStatements = bodyStatements.length
-
-  return t.jsxAttribute(
-    t.jSXIdentifier('css'),
-    t.jSXExpressionContainer(
-      t.arrowFunctionExpression(
-        [t.identifier(themeIdentifier)],
-        hasBodyStatements
-          ? t.blockStatement([
-              ...bodyStatements,
-              t.returnStatement(t.objectExpression(mergedProperties)),
-            ])
-          : t.objectExpression(mergedProperties),
-      ),
-    ),
-  )
-}
 
 /**
  * Primary visitor. Visits all JSX components transpiles any system
@@ -382,15 +23,16 @@ const buildMergedCssAttr = (context, objectProperties, existingCssAttr) => {
  */
 const jsxOpeningElementVisitor = {
   JSXOpeningElement(path, { optionsContext }) {
-    if (svgTags.includes(path.node.name.name)) return
-
     const context = {
       propsToPass: [],
       ...optionsContext,
     }
     const { breakpoints, propsToPass, stylingLibrary } = context
 
-    const systemProps = onlySystemProps(context, path.node.attributes)
+    // All props on this JSX Element
+    const nodeAttrs = path.node.attributes
+
+    const systemProps = onlySystemProps(context, nodeAttrs)
     const cssObjectProperties = buildCssObjectProperties(
       context,
       systemProps,
@@ -399,27 +41,29 @@ const jsxOpeningElementVisitor = {
 
     if (!cssObjectProperties.length) return
 
-    const existingCssAttr = path.node.attributes.find(
-      attr => attr.name.name === 'css',
-    )
-
+    const existingCssAttr = nodeAttrs.find(attr => attr.name.name === 'css')
     const newCssAttr = existingCssAttr
       ? buildMergedCssAttr(context, cssObjectProperties, existingCssAttr)
       : buildCssAttr(context, cssObjectProperties)
 
-    path.node.attributes = notSystemProps(context, path.node.attributes).filter(
+    // Remove the existing `css` prop, if there is one.
+    path.node.attributes = notSystemProps(context, nodeAttrs).filter(
       attr => attr.name.name !== 'css',
     )
+
+    // Add our new `css` prop.
     if (newCssAttr) path.node.attributes.push(newCssAttr)
 
+    // For styled-components, we need to pass any runtime identifiers as props to
+    // the `styled.div` that their babel plugin generates. This is because the
+    // `styled.div` is generated outside the scope of this JSX element.
     const internalProps = Object.entries(propsToPass).map(([propName, attrs]) =>
       t.objectProperty(t.identifier(propName), t.arrayExpression(attrs)),
     )
-
     if (stylingLibrary === 'styled-components' && internalProps.length)
       path.node.attributes.push(
         t.jsxAttribute(
-          t.jsxIdentifier('__styleProps'),
+          t.jsxIdentifier(INTERNAL_PROP_ID),
           t.jsxExpressionContainer(t.objectExpression(internalProps)),
         ),
       )

--- a/packages/babel-plugin/src/utils.js
+++ b/packages/babel-plugin/src/utils.js
@@ -1,3 +1,5 @@
+import { types as t } from '@babel/core'
+
 import { SYSTEM_PROPS } from './constants'
 
 /**
@@ -42,3 +44,12 @@ export const notSystemProps = (context, attrs) => {
     attr => !Boolean(SYSTEM_PROPS[attr.name.name] || variants[attr.name.name]),
   )
 }
+
+/**
+ * Checks if the provided Babel node is skippable by checking
+ * if it is `null`.
+ *
+ * @param {Object} attrValue - Babel node to check.
+ * @returns `true` if it is skippable, `false` otherwise.
+ */
+export const shouldSkipProp = attrValue => t.isNullLiteral(attrValue)


### PR DESCRIPTION
This PR refactors all globals like `propsToPass`, `themeIdentifier`, etc. to be passed via `context` instead.

All builders and utilities now receive `context` as the first parameter, giving them access to shared values.